### PR TITLE
Add initial Markdown documentation for main.f90 and atom.f90

### DIFF
--- a/docs/atom.md
+++ b/docs/atom.md
@@ -1,0 +1,72 @@
+# `src/atom.f90`
+
+## Overview
+
+The `atom.f90` file contains the `atom` subroutine, which is responsible for solving the Dirac-Kohn-Sham equations for a single atom. It calculates self-consistent radial wavefunctions, eigenvalues, charge densities, and potentials for an isolated atom using a specified exchange-correlation functional. This is a fundamental routine for initializing calculations, particularly for determining the starting atomic densities.
+
+## Key Components
+
+*   `subroutine atom(...)`: The main subroutine in this file.
+    *   Takes various input parameters defining the atom (nuclear charge, states, quantum numbers, mesh, XC functional type, etc.).
+    *   Performs a self-consistent calculation to solve the Dirac-Kohn-Sham equations.
+    *   Outputs eigenvalues, charge density, self-consistent potential, and radial wavefunctions.
+
+## Important Variables/Constants
+
+*   **Input Arguments:**
+    *   `sol` (real): Speed of light in atomic units.
+    *   `ptnucl` (logical): If `.true.`, the nucleus is treated as a point particle.
+    *   `zn` (real): Nuclear charge.
+    *   `nst` (integer): Number of atomic states to solve for.
+    *   `n(nst)` (integer array): Principal quantum number for each state.
+    *   `l(nst)` (integer array): Orbital angular momentum quantum number for each state.
+    *   `k(nst)` (integer array): Relativistic quantum number `kappa` for each state.
+    *   `occ(nst)` (real array, inout): Occupancy of each state.
+    *   `xctype(3)` (integer array): Defines the type of exchange-correlation functional.
+    *   `xcgrad` (integer): Flag for GGA functional (1 if GGA, 0 otherwise).
+    *   `np` (integer): Order of the predictor-corrector polynomial for numerical integration.
+    *   `nr` (integer): Number of radial mesh points.
+    *   `r(nr)` (real array): The radial mesh itself.
+*   **Output Arguments:**
+    *   `eval(nst)` (real array): Eigenvalue for each state (without rest-mass energy).
+    *   `rho(nr)` (real array): The total electronic charge density on the radial mesh.
+    *   `vr(nr)` (real array): The self-consistent potential on the radial mesh (includes Hartree, XC, and nuclear contributions).
+    *   `rwf(nr,2,nst)` (real array): Major and minor components of the radial wavefunctions for each state.
+*   **Internal Parameters & Variables:**
+    *   `maxscl` (integer, parameter): Maximum number of self-consistency iterations (default: 200).
+    *   `fourpi` (real, parameter): Value of 4*pi.
+    *   `eps` (real, parameter): Convergence tolerance for the potential (default: 1.d-6).
+    *   `beta` (real): Mixing parameter for self-consistency loop, adaptively changed.
+    *   `vn(:)` (real array): Nuclear potential.
+    *   `vh(:)` (real array): Hartree potential.
+    *   `vx(:)` (real array): Exchange potential.
+    *   `vc(:)` (real array): Correlation potential.
+    *   `vrp(:)` (real array): Potential from the previous iteration (for mixing).
+    *   `dv` (real): RMS difference in potential between iterations.
+
+## Usage Examples
+
+The `atom` subroutine is typically called internally by other parts of the Elk code, for instance, during the initialization phase to generate starting atomic densities or when setting up species data. It's not usually called directly by a user in an input file.
+
+A conceptual call might look like this from within another Fortran routine:
+
+```fortran
+use modxcifc ! For xcifc interface
+! ... define all input parameters for atom ...
+call atom(sol_au, .true., atomic_number_Au, num_states_Au, n_quantum_Au, &
+          l_quantum_Au, k_quantum_Au, occupations_Au, xc_type_lda, 0, &
+          radial_poly_order, num_radial_points, radial_mesh_Au, &
+          eigenvalues_Au, charge_density_Au, potential_Au, wavefunctions_Au)
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `modxcifc`: This module provides the `xcifc` interface, which is used to calculate exchange-correlation energies and potentials based on the `xctype` and `xcgrad` inputs.
+    *   `rdirac` (subroutine): Called to solve the radial Dirac equation for each state. (Implicitly used, definition likely in `rdirac.f90` or a similar file).
+    *   `potnucl` (subroutine): Called to set up the nuclear potential. (Implicitly used, definition likely in `potnucl.f90` or a similar file).
+    *   `fderiv` (subroutine): Called to compute derivatives of functions on the radial mesh (e.g., for GGA). (Implicitly used, definition likely in a utility/math module).
+*   **External Libraries**:
+    *   None directly called from `atom.f90`, but `xcifc` might link to external libraries like `libxc` if Elk is compiled with it.
+
+The subroutine implements a self-consistent field (SCF) loop to solve the atomic problem. It iteratively computes wavefunctions, densities, and potentials until the change in potential between iterations is below the `eps` tolerance or `maxscl` iterations are reached.

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,0 +1,65 @@
+# `src/main.f90`
+
+## Overview
+
+The `main.f90` file is the main program unit for the Elk code. Elk is an all-electron full-potential linearised augmented-plane-wave (FP-LAPW) code used for determining the properties of crystalline solids. This file orchestrates the overall execution flow, including MPI initialization, input reading, task dispatching, and MPI finalization.
+
+## Key Components
+
+*   `program main`: The main entry point of the Elk code.
+    *   Initializes the MPI environment.
+    *   Calls `readinput` to read user-defined parameters.
+    *   Iterates through the specified tasks, calling appropriate subroutines for each task.
+    *   Finalizes the MPI environment before exiting.
+*   `readinput` (subroutine, called by `main`): Responsible for reading all input files, including `elk.in` and species files. (Implicitly used, actual definition is in `readinput.f90`)
+*   Various subroutines for specific tasks (e.g., `gndstate`, `dos`, `bandstr`, `phonon`, etc.): These are called by `main` based on the `task` variable. (Implicitly used, actual definitions are in their respective `.f90` files)
+
+## Important Variables/Constants
+
+*   `itask` (integer): Loop variable for iterating through tasks.
+*   `task` (integer, from `modmain`): The current task number being processed. Read from the `tasks` array.
+*   `tasks` (array, from `modmain`): An array holding the sequence of tasks to be performed, as defined in the input file.
+*   `ntasks` (integer, from `modmain`): The total number of tasks to be performed.
+*   `version` (real, from `modmain`): The version number of the Elk code.
+*   `mpi_comm_world` (integer, from `modmpi`): MPI communicator.
+*   `np_mpi` (integer, from `modmpi`): Total number of MPI processes.
+*   `lp_mpi` (integer, from `modmpi`): Local MPI process rank (0 for master).
+*   `mp_mpi` (logical, from `modmpi`): Flag indicating if the current process is the master MPI process (`.true.` if `lp_mpi == 0`).
+*   `ierror` (integer, from `modmpi`): Error code for MPI calls.
+
+## Usage Examples
+
+The `main.f90` file is not directly used as a library or module with callable functions in the traditional sense. It is the main executable program. To run the Elk code, you compile `main.f90` along with all other source files and then execute the resulting binary. The behavior of the code is controlled by the `elk.in` input file.
+
+An example of how Elk is typically run:
+
+```bash
+# Compile Elk (simplified)
+make
+
+# Run Elk in the current directory (assuming elk.in is present)
+./elk
+```
+
+The `elk.in` file would contain blocks defining tasks, for example:
+
+```
+tasks
+ 10  ! Calculate Density of States
+ 20  ! Calculate band structure
+```
+
+The `main` program reads these tasks and calls the corresponding routines (`dos`, `bandstr`).
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `modmain`: Contains main program variables and task definitions.
+    *   `modmpi`: Contains MPI related variables and wrapper functions.
+    *   Numerous other modules and subroutines corresponding to specific tasks (e.g., `gndstate.f90`, `dos.f90`, `bandstr.f90`, `readinput.f90`, etc.). The `main` program acts as a central dispatcher to these routines.
+*   **External Libraries**:
+    *   MPI (Message Passing Interface): Used for parallel execution.
+    *   Potentially BLAS/LAPACK if linked during compilation (though not directly visible in `main.f90`'s logic, it's used by many computational routines called by `main`).
+    *   Potentially libxc if linked (used by routines called by `main` for exchange-correlation functionals).
+
+The file also contains extensive comments formatted for the Protex documentation system, which effectively serves as the user manual for the Elk code, detailing input parameters, compilation, and contribution guidelines.


### PR DESCRIPTION
This commit introduces Markdown documentation files for two core Fortran files:

- `src/main.f90`: The main program for the Elk code.
- `src/atom.f90`: Solves the Dirac-Kohn-Sham equations for an atom.

The documentation files are located in the `docs/` directory and follow a standard template including sections for Overview, Key Components, Important Variables/Constants, Usage Examples, and Dependencies/Interactions.